### PR TITLE
Add ALIS as a UE5 codebase for study

### DIFF
--- a/README.md
+++ b/README.md
@@ -491,6 +491,7 @@ Learn
 
 ### General Game Development
 
+* :free: [ALIS](https://github.com/fallintodusk/alis#alis-as-an-unreal-engine-architecture-reference) - Documented UE5 C++ survival codebase showing separation of concerns through plugin tiers, server-side MET-based metabolism, and JSON-first editor tooling. :octocat:
 * :moneybag: [Coursera: Beginning Game Programming with C#](https://www.coursera.org/course/gameprogramming)
 * :moneybag: [Coursera: Introduction to interactive Python programming](https://www.coursera.org/course/interactivepython1)
 * :free: [HandmadeHero: making 2D game from scratch](https://handmadehero.org/)


### PR DESCRIPTION
Why do you think the link is worth adding on this list?

Disclosure: this is a self-submission from ALIS.

ALIS is an in-development UE5 survival game whose public C++ code and documentation can be studied as a separation-of-concerns example: plugin-tier ownership, server-side MET-based survival metabolism, server-authoritative inventory, and an integrated three-stage editor workflow.

General Game Development is the honest fit because ALIS is not a standalone engine and its public source tree is not an asset-complete "Complete Game Source."

Does this project has any License?

Yes. Code is AGPL-3.0-only, documentation is MPL-2.0, and world content is CC BY-NC-SA 4.0. The complete Unreal asset payload is not published in the source repository.